### PR TITLE
[SDK:72]: Included .pem files in build output

### DIFF
--- a/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
+++ b/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
@@ -23,4 +23,13 @@
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="test-key-invalid-format.pem">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="test-key.pem">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Included .pem files in build output, as this was behaviour was lost during the migration to VS2017