### PR TITLE
[SDK-72]: Removed global.json file

### DIFF
--- a/src/Yoti.Auth.sln
+++ b/src/Yoti.Auth.sln
@@ -3,11 +3,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26730.12
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{CE1F453E-BD56-4A3A-9B87-44A6C9D63D1A}"
-	ProjectSection(SolutionItems) = preProject
-		..\test\global.json = ..\test\global.json
-	EndProjectSection
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yoti.Auth", "Yoti.Auth\Yoti.Auth.csproj", "{FD86A254-0965-4748-9D10-782EEEA23D07}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yoti.Auth.Owin", "Yoti.Auth.Owin\Yoti.Auth.Owin.csproj", "{BD1F1AA6-C506-4BFF-BE6D-145E4771F188}"


### PR DESCRIPTION
Removed global.json file, which is no longer required in VS2017 (this information is captured in the new .csproj file). This seems to have been missed out of the migration, but it should have been removed - see https://github.com/dotnet/project-system/issues/1184