### PR TITLE
[SDK-72]: Set up project to work with OpenCover & ReportGenerator

### DIFF
--- a/src/Yoti.Auth.Owin/Yoti.Auth.Owin.csproj
+++ b/src/Yoti.Auth.Owin/Yoti.Auth.Owin.csproj
@@ -10,6 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <DebugType>Full</DebugType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -55,5 +56,4 @@
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-
 </Project>

--- a/src/Yoti.Auth/Yoti.Auth.csproj
+++ b/src/Yoti.Auth/Yoti.Auth.csproj
@@ -10,6 +10,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <DebugType>Full</DebugType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -47,5 +48,4 @@
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-
 </Project>

--- a/test/Yoti.Auth.Tests/RunOpenCover.bat
+++ b/test/Yoti.Auth.Tests/RunOpenCover.bat
@@ -1,0 +1,9 @@
+@ECHO OFF
+
+REM Get OpenCover Executable (so we dont have to change the code when the version number changes)
+for /R "%~dp0packages" %%a in (*) do if /I "%%~nxa"=="OpenCover.Console.exe" SET OpenCoverExe=%%~dpnxa
+
+SET Filter="+[Yoti.Auth]* +[Yoti.Auth.Owin]* -[Yoti.Auth.Tests]*"
+SET OutputFile=..\..\..\OpenCover\Yoti.Auth.Tests\coverage.xml
+
+%OpenCoverExe% "-target:%ProgramFiles%\dotnet\dotnet.exe" -targetargs:test -register:user -filter:%Filter% -output:%OutputFile% -oldStyle

--- a/test/Yoti.Auth.Tests/RunReportGenerator.bat
+++ b/test/Yoti.Auth.Tests/RunReportGenerator.bat
@@ -1,0 +1,10 @@
+@ECHO OFF
+
+REM Get Report Generator (so we dont have to change the code when the version number changes)
+for /R "%~dp0packages" %%a in (*) do if /I "%%~nxa"=="ReportGenerator.exe" SET ReportGeneratorExe=%%~dpnxa
+
+SET OutputDirectory=..\..\..\OpenCover\Yoti.Auth.Tests
+
+%ReportGeneratorExe% -targetdir:%OutputDirectory%\Coverage -reporttypes:Html;Badges -reports:%OutputDirectory%\Coverage.xml  -verbosity:Error
+ 
+start "report" "%OutputDirectory%\Coverage\index.htm"

--- a/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
+++ b/test/Yoti.Auth.Tests/Yoti.Auth.Tests.csproj
@@ -11,6 +11,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <DebugType>Full</DebugType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,6 +22,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.8-rc" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.8-rc" />
+    <PackageReference Include="OpenCover" Version="4.6.519" />
+    <PackageReference Include="ReportGenerator" Version="2.5.11" />
   </ItemGroup>
 
   <ItemGroup>
@@ -31,5 +34,4 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Set up project to work with OpenCover & ReportGenerator, so that we can generate code coverage reports