### PR TITLE
[SDK-72]: Excluded Google.Protobuf assemblies from Code Coverage

### DIFF
--- a/test/Yoti.Auth.Tests/RunOpenCover.bat
+++ b/test/Yoti.Auth.Tests/RunOpenCover.bat
@@ -3,7 +3,10 @@
 REM Get OpenCover Executable (so we dont have to change the code when the version number changes)
 for /R "%~dp0packages" %%a in (*) do if /I "%%~nxa"=="OpenCover.Console.exe" SET OpenCoverExe=%%~dpnxa
 
-SET Filter="+[Yoti.Auth]* +[Yoti.Auth.Owin]* -[Yoti.Auth.Tests]*"
+SET ProtoBufAttributeNamespace=AttrpubapiV1
+SET ProtoBufCommonNamespace=CompubapiV1
+
+SET Filter="+[Yoti.Auth]* +[Yoti.Auth.Owin]* -[Yoti.Auth.Tests]* -[Yoti.Auth]%ProtoBufAttributeNamespace%* -[Yoti.Auth]%ProtoBufCommonNamespace%*"
 SET OutputFile=..\..\..\OpenCover\Yoti.Auth.Tests\coverage.xml
 
 %OpenCoverExe% "-target:%ProgramFiles%\dotnet\dotnet.exe" -targetargs:test -register:user -filter:%Filter% -output:%OutputFile% -oldStyle


### PR DESCRIPTION
Excluded assemblies produced by the Google.Protobuf NuGet package. These are auto-generated, and contain code which we aren't utlising in this project. It doesn't make sense to write code to test the parts which we're not using. For the next check-in I'll look at testing every part of this ProtoBuf package that we integrate with.