### PR TITLE
[SDK-72]: Added Tests for HttpRequester class

### DIFF
--- a/src/Yoti.Auth/HttpRequester.cs
+++ b/src/Yoti.Auth/HttpRequester.cs
@@ -7,7 +7,7 @@ namespace Yoti.Auth
 {
     internal class HttpRequester : IHttpRequester
     {
-        public async Task<Response> DoRequest(Uri uri, Dictionary<string, string> headers)
+        public async Task<Response> DoRequest(HttpClient httpClient, Uri uri, Dictionary<string, string> headers)
         {
             Response result = new Response
             {
@@ -16,7 +16,7 @@ namespace Yoti.Auth
                 Content = null,
             };
 
-            using (var client = new HttpClient())
+            using (var client = httpClient)
             {
                 using (var request = new HttpRequestMessage())
                 {

--- a/src/Yoti.Auth/IHttpRequester.cs
+++ b/src/Yoti.Auth/IHttpRequester.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace Yoti.Auth
 {
     internal interface IHttpRequester
     {
-        Task<Response> DoRequest(Uri uri, Dictionary<string, string> headers);
+        Task<Response> DoRequest(HttpClient httpClient, Uri uri, Dictionary<string, string> headers);
     }
 }

--- a/src/Yoti.Auth/YotiClientEngine.cs
+++ b/src/Yoti.Auth/YotiClientEngine.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using AttrpubapiV1;
 using CompubapiV1;
@@ -58,7 +59,10 @@ namespace Yoti.Auth
             headers.Add("X-Yoti-Auth-Key", authKey);
             headers.Add("X-Yoti-Auth-Digest", authDigest);
 
-            var response = await _httpRequester.DoRequest(new Uri(_apiUrl + endpoint), headers);
+            var response = await _httpRequester.DoRequest(
+                new HttpClient(),
+                new Uri(_apiUrl + endpoint),
+                headers);
 
             if (response.Success)
             {

--- a/test/Yoti.Auth.Tests/FakeHttpRequester.cs
+++ b/test/Yoti.Auth.Tests/FakeHttpRequester.cs
@@ -1,21 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace Yoti.Auth.Tests
 {
     internal class FakeHttpRequester : IHttpRequester
     {
-        private readonly Func<Uri, Dictionary<string, string>, Task<Response>> _doRequest;
+        private readonly Func<HttpClient, Uri, Dictionary<string, string>, Task<Response>> _doRequest;
 
-        public FakeHttpRequester(Func<Uri, Dictionary<string, string>, Task<Response>> doRequest)
+        public FakeHttpRequester(Func<HttpClient, Uri, Dictionary<string, string>, Task<Response>> doRequest)
         {
             _doRequest = doRequest;
         }
 
-        public Task<Response> DoRequest(Uri uri, Dictionary<string, string> headers)
+        public Task<Response> DoRequest(HttpClient httpClient, Uri uri, Dictionary<string, string> headers)
         {
-            return _doRequest(uri, headers);
+            return _doRequest(httpClient, uri, headers);
         }
     }
 }

--- a/test/Yoti.Auth.Tests/FakeHttpResponseHandler.cs
+++ b/test/Yoti.Auth.Tests/FakeHttpResponseHandler.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Yoti.Auth.Tests
+{
+    public class FakeHttpResponseHandler : DelegatingHandler
+    {
+        private readonly Dictionary<Uri, HttpResponseMessage> _FakeResponses = new Dictionary<Uri, HttpResponseMessage>();
+
+        public void AddFakeResponse(Uri uri, HttpResponseMessage responseMessage)
+        {
+            _FakeResponses.Add(uri, responseMessage);
+        }
+
+        protected async override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (_FakeResponses.ContainsKey(request.RequestUri))
+            {
+                HttpResponseMessage response = _FakeResponses[request.RequestUri];
+                response.Content = new StringContent("Content");
+                return await Task.FromResult(response);
+            }
+            else
+            {
+                return new HttpResponseMessage(HttpStatusCode.NotFound) { RequestMessage = request };
+            }
+        }
+    }
+}

--- a/test/Yoti.Auth.Tests/HttpRequester_Tests.cs
+++ b/test/Yoti.Auth.Tests/HttpRequester_Tests.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Yoti.Auth.Tests
+{
+    [TestClass]
+    public class HttpRequester_Tests
+    {
+        private const string _apiUrl = @"https://api.yoti.com/api/v1";
+        private Dictionary<string, string> _headers = new Dictionary<string, string>();
+        private FakeHttpResponseHandler _fakeResponseHandler;
+        private HttpRequester _httpRequester;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            _fakeResponseHandler = new FakeHttpResponseHandler();
+            _httpRequester = new HttpRequester();
+            _headers.Add("Key", "Value");
+        }
+
+        [TestMethod]
+        public void HttpRequester_SuccessStatusCode_ReturnsSuccess()
+        {
+            _fakeResponseHandler.AddFakeResponse(
+                new Uri(_apiUrl),
+                new HttpResponseMessage(HttpStatusCode.OK));
+
+            var httpClient = new HttpClient(_fakeResponseHandler);
+            Task<Response> response = _httpRequester.DoRequest(
+                httpClient,
+                new Uri(_apiUrl),
+                _headers);
+
+            Assert.IsTrue(response.Result.Success);
+        }
+
+        [TestMethod]
+        public void HttpRequester_BadRequestStatusCode_ReturnsFailure()
+        {
+            _fakeResponseHandler.AddFakeResponse(
+                new Uri(_apiUrl),
+                new HttpResponseMessage(HttpStatusCode.BadRequest));
+
+            var httpClient = new HttpClient(_fakeResponseHandler);
+            Task<Response> response = _httpRequester.DoRequest(
+                httpClient,
+                new Uri(_apiUrl),
+                _headers);
+
+            Assert.IsFalse(response.Result.Success);
+        }
+    }
+}

--- a/test/Yoti.Auth.Tests/YotiClientEngine_Tests.cs
+++ b/test/Yoti.Auth.Tests/YotiClientEngine_Tests.cs
@@ -27,7 +27,7 @@ namespace Yoti.Auth.Tests
             var keyPair = GetKeyPair();
             string sdkId = "fake-sdk-id";
 
-            FakeHttpRequester httpRequester = new FakeHttpRequester((uri, headers) =>
+            FakeHttpRequester httpRequester = new FakeHttpRequester((httpClient, uri, headers) =>
             {
                 return Task.FromResult(new Response
                 {
@@ -50,7 +50,7 @@ namespace Yoti.Auth.Tests
             var keyPair = GetKeyPair();
             string sdkId = "fake-sdk-id";
 
-            FakeHttpRequester httpRequester = new FakeHttpRequester((uri, headers) =>
+            FakeHttpRequester httpRequester = new FakeHttpRequester((httpClient, uri, headers) =>
             {
                 return Task.FromResult(new Response
                 {
@@ -73,7 +73,7 @@ namespace Yoti.Auth.Tests
             var keyPair = GetKeyPair();
             string sdkId = "fake-sdk-id";
 
-            FakeHttpRequester httpRequester = new FakeHttpRequester((uri, headers) =>
+            FakeHttpRequester httpRequester = new FakeHttpRequester((httpClient, uri, headers) =>
             {
                 return Task.FromResult(new Response
                 {
@@ -97,7 +97,7 @@ namespace Yoti.Auth.Tests
             var keyPair = GetKeyPair();
             string sdkId = "fake-sdk-id";
 
-            FakeHttpRequester httpRequester = new FakeHttpRequester((uri, headers) =>
+            FakeHttpRequester httpRequester = new FakeHttpRequester((httpClient, uri, headers) =>
             {
                 return Task.FromResult(new Response
                 {
@@ -121,7 +121,7 @@ namespace Yoti.Auth.Tests
             var keyPair = GetKeyPair();
             string sdkId = "fake-sdk-id";
 
-            FakeHttpRequester httpRequester = new FakeHttpRequester((uri, headers) =>
+            FakeHttpRequester httpRequester = new FakeHttpRequester((httpClient, uri, headers) =>
             {
                 Assert.AreEqual("/api/v1/profile/" + token, uri.AbsolutePath);
 
@@ -147,7 +147,7 @@ namespace Yoti.Auth.Tests
             string other_party_profile_content = "ChCZAib1TBm9Q5GYfFrS1ep9EnAwQB5shpAPWLBgZgFgt6bCG3S5qmZHhrqUbQr3yL6yeLIDwbM7x4nuT/MYp+LDXgmFTLQNYbDTzrEzqNuO2ZPn9Kpg+xpbm9XtP7ZLw3Ep2BCmSqtnll/OdxAqLb4DTN4/wWdrjnFC+L/oQEECu646";
             string remember_me_id = "remember_me_id0123456789";
 
-            FakeHttpRequester httpRequester = new FakeHttpRequester((uri, headers) =>
+            FakeHttpRequester httpRequester = new FakeHttpRequester((httpClient, uri, headers) =>
             {
                 return Task.FromResult(new Response
                 {


### PR DESCRIPTION
This Required a small amount of restructuring to allow the FakeHttpResponseHandler to be incorporated 