### PR TITLE
[SDK-91]: Modified assemblies for new NuGet package

### DIFF
--- a/src/Yoti.Auth.Owin.nuspec
+++ b/src/Yoti.Auth.Owin.nuspec
@@ -1,53 +1,39 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Yoti.Auth.Owin</id>
-    <version>1.0.1</version>
-    <authors>Ben Harpin</authors>
-    <owners>Ben Harpin</owners>
+    <id>Yoti.Owin</id>
+    <version>2.0.0</version>
+    <authors>Yoti</authors>
+    <owners>Yoti</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Yoti Owin .NET SDK</description>
-    <copyright>Copyright 2016</copyright>
+    <description>Yoti Owin .NET SDK. Yoti is an identity checking system that allows organisations to verify who people are.</description>
+    <copyright>Copyright 2017</copyright>
+	<tags>authentication auth login identity</tags>
 	<dependencies>
       <group targetFramework="net45">
         <dependency id="Microsoft.AspNet.Identity.Owin" version="2.2.1" />
         <dependency id="Microsoft.Owin.Security" version="3.0.1" />
-        <dependency id="System.Net.Http" version="4.0.0" />
-		<dependency id="Google.Protobuf" version="3.0.0" />
-		<dependency id="Newtonsoft.Json" version="9.0.1" />
-		<dependency id="Portable.BouncyCastle" version="1.8.1.1" />
+        <dependency id="System.Net.Http" version="4.1.1" />		
       </group>
       <group targetFramework="net451">
         <dependency id="Microsoft.AspNet.Identity.Owin" version="2.2.1" />
         <dependency id="Microsoft.Owin.Security" version="3.0.1" />
-        <dependency id="System.Net.Http" version="4.0.0" />
-		<dependency id="Google.Protobuf" version="3.0.0" />
-		<dependency id="Newtonsoft.Json" version="9.0.1" />
-		<dependency id="Portable.BouncyCastle" version="1.8.1.1" />
+        <dependency id="System.Net.Http" version="4.1.1" />		
       </group>
       <group targetFramework="net452">
         <dependency id="Microsoft.AspNet.Identity.Owin" version="2.2.1" />
         <dependency id="Microsoft.Owin.Security" version="3.0.1" />
-        <dependency id="System.Net.Http" version="4.0.0" />
-		<dependency id="Google.Protobuf" version="3.0.0" />
-		<dependency id="Newtonsoft.Json" version="9.0.1" />
-		<dependency id="Portable.BouncyCastle" version="1.8.1.1" />
+        <dependency id="System.Net.Http" version="4.1.1" />		
       </group>
       <group targetFramework="net46">
         <dependency id="Microsoft.AspNet.Identity.Owin" version="2.2.1" />
         <dependency id="Microsoft.Owin.Security" version="3.0.1" />
-        <dependency id="System.Net.Http" version="4.1.0" />
-		<dependency id="Google.Protobuf" version="3.0.0" />
-		<dependency id="Newtonsoft.Json" version="9.0.1" />
-		<dependency id="Portable.BouncyCastle" version="1.8.1.1" />
+        <dependency id="System.Net.Http" version="4.1.1" />		
       </group>
       <group targetFramework="net461">
         <dependency id="Microsoft.AspNet.Identity.Owin" version="2.2.1" />
         <dependency id="Microsoft.Owin.Security" version="3.0.1" />
-        <dependency id="System.Net.Http" version="4.1.0" />
-		<dependency id="Google.Protobuf" version="3.0.0" />
-		<dependency id="Newtonsoft.Json" version="9.0.1" />
-		<dependency id="Portable.BouncyCastle" version="1.8.1.1" />
+        <dependency id="System.Net.Http" version="4.1.1" />				
       </group>
     </dependencies>
   </metadata>

--- a/src/Yoti.Auth.Owin/Properties/AssemblyInfo.cs
+++ b/src/Yoti.Auth.Owin/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Yoti")]
 [assembly: AssemblyProduct("Yoti.Owin.Security")]
 [assembly: AssemblyTrademark("")]
 

--- a/src/Yoti.Auth.Owin/Yoti.Auth.Owin.csproj
+++ b/src/Yoti.Auth.Owin/Yoti.Auth.Owin.csproj
@@ -1,16 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <TargetFrameworks>netstandard1.6;net45;net451;net452;net46;net461</TargetFrameworks>
     <AssemblyName>Yoti.Auth.Owin</AssemblyName>
-    <PackageId>Yoti.Auth.Owin</PackageId>
+    <PackageId>Yoti.Owin</PackageId>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <DebugType>Full</DebugType>
+    <Authors>Yoti,Edward.Harrod</Authors>
+    <Description>Yoti Owin .NET SDK</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Yoti.Auth.nuspec
+++ b/src/Yoti.Auth.nuspec
@@ -1,46 +1,44 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Yoti.Auth</id>
-    <version>1.0.1</version>
-    <authors>Ben Harpin</authors>
-    <owners>Ben Harpin</owners>
+    <id>Yoti</id>
+    <version>2.0.0</version>
+    <authors>Yoti</authors>
+    <owners>Yoti</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Yoti .NET SDK</description>
-    <copyright>Copyright 2016</copyright>
+    <description>Yoti .NET SDK. Yoti is an identity checking system that allows organisations to verify who people are.</description>
+    <copyright>Copyright 2017</copyright>
+	<tags>authentication auth login identity</tags>
 	<dependencies>
       <group targetFramework="netstandard1.6">
-        <dependency id="NETStandard.Library" version="1.6.0" />
-		<dependency id="Google.Protobuf" version="3.0.0" />
-		<dependency id="Newtonsoft.Json" version="9.0.1" />
-		<dependency id="Portable.BouncyCastle" version="1.8.1.1" />
+        <dependency id="NETStandard.Library" version="1.6.0" />		
       </group>
       <group targetFramework="net45">
-        <dependency id="System.Net.Http" version="4.0.0" />
+        <dependency id="System.Net.Http" version="4.1.1" />		
 		<dependency id="Google.Protobuf" version="3.0.0" />
 		<dependency id="Newtonsoft.Json" version="9.0.1" />
 		<dependency id="Portable.BouncyCastle" version="1.8.1.1" />
       </group>
       <group targetFramework="net451">
-        <dependency id="System.Net.Http" version="4.0.0" />
+        <dependency id="System.Net.Http" version="4.1.1" />	
 		<dependency id="Google.Protobuf" version="3.0.0" />
 		<dependency id="Newtonsoft.Json" version="9.0.1" />
-		<dependency id="Portable.BouncyCastle" version="1.8.1.1" />
+		<dependency id="Portable.BouncyCastle" version="1.8.1.1" />		
       </group>
       <group targetFramework="net452">
-        <dependency id="System.Net.Http" version="4.0.0" />
+        <dependency id="System.Net.Http" version="4.1.1" />		
 		<dependency id="Google.Protobuf" version="3.0.0" />
 		<dependency id="Newtonsoft.Json" version="9.0.1" />
 		<dependency id="Portable.BouncyCastle" version="1.8.1.1" />
       </group>
       <group targetFramework="net46">
-        <dependency id="System.Net.Http" version="4.1.0" />
+        <dependency id="System.Net.Http" version="4.1.0" />	
 		<dependency id="Google.Protobuf" version="3.0.0" />
 		<dependency id="Newtonsoft.Json" version="9.0.1" />
-		<dependency id="Portable.BouncyCastle" version="1.8.1.1" />
+		<dependency id="Portable.BouncyCastle" version="1.8.1.1" />		
       </group>
       <group targetFramework="net461">
-        <dependency id="System.Net.Http" version="4.1.0" />
+        <dependency id="System.Net.Http" version="4.1.0" />		
 		<dependency id="Google.Protobuf" version="3.0.0" />
 		<dependency id="Newtonsoft.Json" version="9.0.1" />
 		<dependency id="Portable.BouncyCastle" version="1.8.1.1" />

--- a/src/Yoti.Auth/Properties/AssemblyInfo.cs
+++ b/src/Yoti.Auth/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Yoti")]
 [assembly: AssemblyProduct("Yoti.Auth")]
 [assembly: AssemblyTrademark("")]
 

--- a/src/Yoti.Auth/Yoti.Auth.csproj
+++ b/src/Yoti.Auth/Yoti.Auth.csproj
@@ -1,16 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <TargetFrameworks>netstandard1.6;net45;net451;net452;net46;net461</TargetFrameworks>
     <AssemblyName>Yoti.Auth</AssemblyName>
-    <PackageId>Yoti.Auth</PackageId>
+    <PackageId>Yoti</PackageId>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <DebugType>Full</DebugType>
+    <Authors>Yoti,Edward.Harrod</Authors>
+    <Description>Yoti .NET SDK</Description>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
After renaming the solution and project names, it didn't seem right to have both being called Yoti. After researching traditional naming structures, it seemed that Company.ProductName.Project is the best way to go, so I have kept the Project as Yoti.Auth. However, I have changed the PackageId to be Yoti, so that we can reserve this on NuGet, and the user types 
`Install-Package Yoti` to install.

I have changed the version to be 2.0.0. Technically, it could have been 1.0.0, as it's a different package name, but I thought this might be confusing, given the choice between Yoti.Auth 1.1.0, and Yoti 1.0.0.

I removed some of the references in Yoti.Auth.Owin.nuspec, as these are not required. 
I have tested these changes with a local NuGet package repository with the Example and IdentityExample projects. Once these changes have been approved, I will publish the package, and update the Example projects to reference this new package. 

