### PR TITLE
[SDK-91]: Updated description and tags of NuGet package specification

### DIFF
--- a/src/Yoti.Auth.Owin.nuspec
+++ b/src/Yoti.Auth.Owin.nuspec
@@ -8,7 +8,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Yoti Owin .NET SDK, providing Yoti API support for Login, Verify (2FA) and Age Verification</description>
     <copyright>Copyright 2017</copyright>
-	<tags>2FA Multifactor authentication verification identity login register verify 2Factor</tags>
+	<tags>2FA multifactor authentication verification identity login register verify 2Factor</tags>
 	<dependencies>
       <group targetFramework="net45">
         <dependency id="Microsoft.AspNet.Identity.Owin" version="2.2.1" />

--- a/src/Yoti.Auth.Owin.nuspec
+++ b/src/Yoti.Auth.Owin.nuspec
@@ -6,9 +6,9 @@
     <authors>Yoti</authors>
     <owners>Yoti</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Yoti Owin .NET SDK. Yoti is an identity checking system that allows organisations to verify who people are.</description>
+    <description>Yoti Owin .NET SDK, providing Yoti API support for Login, Verify (2FA) and Age Verification</description>
     <copyright>Copyright 2017</copyright>
-	<tags>authentication auth login identity</tags>
+	<tags>2FA Multifactor authentication verification identity login register verify 2Factor</tags>
 	<dependencies>
       <group targetFramework="net45">
         <dependency id="Microsoft.AspNet.Identity.Owin" version="2.2.1" />

--- a/src/Yoti.Auth.nuspec
+++ b/src/Yoti.Auth.nuspec
@@ -6,9 +6,9 @@
     <authors>Yoti</authors>
     <owners>Yoti</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Yoti .NET SDK. Yoti is an identity checking system that allows organisations to verify who people are.</description>
+    <description>Yoti .NET SDK, providing Yoti API support for Login, Verify (2FA) and Age Verification</description>
     <copyright>Copyright 2017</copyright>
-	<tags>authentication auth login identity</tags>
+	<tags>2FA Multifactor authentication verification identity login register verify 2Factor</tags>
 	<dependencies>
       <group targetFramework="netstandard1.6">
         <dependency id="NETStandard.Library" version="1.6.0" />		

--- a/src/Yoti.Auth.nuspec
+++ b/src/Yoti.Auth.nuspec
@@ -8,7 +8,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Yoti .NET SDK, providing Yoti API support for Login, Verify (2FA) and Age Verification</description>
     <copyright>Copyright 2017</copyright>
-	<tags>2FA Multifactor authentication verification identity login register verify 2Factor</tags>
+	<tags>2FA multifactor authentication verification identity login register verify 2Factor</tags>
 	<dependencies>
       <group targetFramework="netstandard1.6">
         <dependency id="NETStandard.Library" version="1.6.0" />		


### PR DESCRIPTION
Slight change from spec in changing " .net SDK for Yoti API support for Login" to ".NET SDK, providing Yoti API support for Login" (so we're not using 'for' twice)