### PR TITLE
[SDK-93]: Made batch files more user-friendly

### DIFF
--- a/RunOpenCover.bat
+++ b/RunOpenCover.bat
@@ -5,8 +5,12 @@ for /R "%~dp0packages" %%a in (*) do if /I "%%~nxa"=="OpenCover.Console.exe" SET
 
 SET ProtoBufAttributeNamespace=AttrpubapiV1
 SET ProtoBufCommonNamespace=CompubapiV1
+SET OpenCoverDirectory="..\OpenCover"
+
+if not exist %OpenCoverDirectory% mkdir %OpenCoverDirectory%
 
 SET Filter="+[Yoti.Auth]* +[Yoti.Auth.Owin]* -[Yoti.Auth.Tests]* -[Yoti.Auth]%ProtoBufAttributeNamespace%* -[Yoti.Auth]%ProtoBufCommonNamespace%*"
-SET OutputFile=..\..\..\OpenCover\Yoti.Auth.Tests\coverage.xml
+SET OutputFile=%OpenCoverDirectory%\Yoti.Auth.Tests\coverage.xml
+SET TargetArgs="test test/Yoti.Auth.Tests"
 
-%OpenCoverExe% "-target:%ProgramFiles%\dotnet\dotnet.exe" -targetargs:test -register:user -filter:%Filter% -output:%OutputFile% -oldStyle
+%OpenCoverExe% "-target:%ProgramFiles%\dotnet\dotnet.exe" -targetargs:%TargetArgs% -register:user -filter:%Filter% -output:%OutputFile% -oldStyle

--- a/RunOpenCover.bat
+++ b/RunOpenCover.bat
@@ -5,12 +5,12 @@ for /R "%~dp0packages" %%a in (*) do if /I "%%~nxa"=="OpenCover.Console.exe" SET
 
 SET ProtoBufAttributeNamespace=AttrpubapiV1
 SET ProtoBufCommonNamespace=CompubapiV1
-SET OpenCoverDirectory="..\OpenCover"
+SET OpenCoverDirectory="..\OpenCover\Yoti.Auth.Tests"
 
 if not exist %OpenCoverDirectory% mkdir %OpenCoverDirectory%
 
 SET Filter="+[Yoti.Auth]* +[Yoti.Auth.Owin]* -[Yoti.Auth.Tests]* -[Yoti.Auth]%ProtoBufAttributeNamespace%* -[Yoti.Auth]%ProtoBufCommonNamespace%*"
-SET OutputFile=%OpenCoverDirectory%\Yoti.Auth.Tests\coverage.xml
+SET OutputFile=%OpenCoverDirectory%\coverage.xml
 SET TargetArgs="test test/Yoti.Auth.Tests"
 
 %OpenCoverExe% "-target:%ProgramFiles%\dotnet\dotnet.exe" -targetargs:%TargetArgs% -register:user -filter:%Filter% -output:%OutputFile% -oldStyle

--- a/RunReportGenerator.bat
+++ b/RunReportGenerator.bat
@@ -3,8 +3,8 @@
 REM Get Report Generator (so we dont have to change the code when the version number changes)
 for /R "%~dp0packages" %%a in (*) do if /I "%%~nxa"=="ReportGenerator.exe" SET ReportGeneratorExe=%%~dpnxa
 
-SET OutputDirectory=..\..\..\OpenCover\Yoti.Auth.Tests
+SET OutputDirectory=..\OpenCover\Yoti.Auth.Tests
 
 %ReportGeneratorExe% -targetdir:%OutputDirectory%\Coverage -reporttypes:Html;Badges -reports:%OutputDirectory%\Coverage.xml  -verbosity:Error
- 
+
 start "report" "%OutputDirectory%\Coverage\index.htm"


### PR DESCRIPTION
Due to different NuGet configurations putting the \packages folder in different places, I've moved the .bat files which handle the respective OpenCover and ReportGenerator operations to the root of the repo. This will mean it will find other configurations of where the \packages folder might reside. Updated the content of the .bat files themselves to reflect this, and did a small amount of tidying up.