### PR TITLE
[SDK-95]: Fixed bug where Example project was crashing when no photo requested

### DIFF
--- a/src/Example/Controllers/HomeController.cs
+++ b/src/Example/Controllers/HomeController.cs
@@ -15,7 +15,10 @@ namespace Example.Controllers
         {
             var user = GetUser();
 
-            ViewBag.Photo = "data:image/jpeg;base64," + Convert.ToBase64String(user.Photo);
+            if (user.Photo == null)
+                ViewBag.Message = "No photo provided, change the application settings to request a photo from the user for this demo";
+            else
+                ViewBag.Photo = "data:image/jpeg;base64," + Convert.ToBase64String(user.Photo);
 
             return View();
         }

--- a/src/Example/Data/UserManager.cs
+++ b/src/Example/Data/UserManager.cs
@@ -15,6 +15,7 @@ namespace Example.Models
                 return _db.Users.FirstOrDefault(u => u.YotiId == yotiId);
             }
         }
+
         public static User GetUserById(int id)
         {
             using (ApplicationContext _db = new ApplicationContext())
@@ -23,14 +24,17 @@ namespace Example.Models
             }
         }
 
-        public static void SaveUser(User user)
+        public static void SaveUser(User newUser)
         {
             using (ApplicationContext _db = new ApplicationContext())
             {
-                if (user.Id == 0)
+                if (newUser.Id == 0)
                 {
-                    _db.Users.Add(user);
+                    _db.Users.Add(newUser);
                 }
+
+                User currentUser = _db.Users.Single(u => u.Id == newUser.Id);
+                _db.Entry(currentUser).CurrentValues.SetValues(newUser);
 
                 _db.SaveChanges();
             }

--- a/src/Example/Views/Home/Index.cshtml
+++ b/src/Example/Views/Home/Index.cshtml
@@ -6,7 +6,14 @@
     <div class="row">
         <div class="col-md-4 col-sm-6 col-xs-12">
             <div class="thumbnail">
-                <img src="@Html.Raw(ViewBag.Photo)" alt="Responsive image">
+                @if (ViewBag.Photo == null)
+                {
+                    <p>@ViewBag.Message</p>
+                }
+                else
+                {
+                    <img src="@Html.Raw(ViewBag.Photo)" alt="Responsive image">
+                }
             </div>
         </div>
         <div class="col-md-8 col-sm-6 col-xs-12">


### PR DESCRIPTION
Example project was crashing when photo was not requested (and consequently supplied) by the application. Also found other bug in the process - if the application changes the details requested of the user, this new information is never added to the user profile. 